### PR TITLE
Relative protocol path

### DIFF
--- a/www/index.php
+++ b/www/index.php
@@ -1,7 +1,7 @@
 <html>
 <head>
 	<title>Hello world!</title>
-	<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
+	<link href='//fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
 	<style>
 	body {
 		background-color: white;


### PR DESCRIPTION
Use a relative protocol, this way won't break under HTTPS connection when browser try to call google fonts

Got this issue testing `jwilder/nginx-proxy` + `JrCs/docker-letsencrypt-nginx-proxy-companion`